### PR TITLE
fix: 修复因为端口占用，导致 无法初始化 JSDEBUG 执行环境

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "eslint-plugin-node": "^7.0.1",
     "eslint-plugin-promise": "^3.8.0",
     "eslint-plugin-standard": "^3.1.0",
+    "kill-port": "^1.3.2",
     "prettier": "^1.13.7"
   },
   "dependencies": {

--- a/src/index.js
+++ b/src/index.js
@@ -9,6 +9,7 @@ const config = require("./config");
 const debugServer = require("./server");
 const mlink = require("./link");
 const Router = mlink.Router;
+const kill = require('kill-port')
 
 const { logger, hosts, util } = require("./util");
 
@@ -110,6 +111,10 @@ exports.launch = function(ip, port) {
       } else {
         logger.info(`Starting inspector on port ${open}`);
       }
+      process.on('exit', function() {
+        kill(open)
+        kill(port)
+      });
       config.REMOTE_DEBUG_PORT = open;
       headless.launchHeadless(`${config.ip}:${config.port}`, open);
     });


### PR DESCRIPTION
经常通过 ctrl+c 关闭 debugger 进程，然后经常出现端口占用，偶尔出现 无法初始化 JSDEBUG 执行环境，查到原因是
![image](https://user-images.githubusercontent.com/13065289/49275023-fe261780-f4b4-11e8-997d-a4c5b7b5f6f9.png)
```js
urlObj.port === config.port + "" // 端口占用导致两者有可能不相等
```